### PR TITLE
Various improvements to Gauss-Chebyshev equations

### DIFF
--- a/include/integratorxx/quadratures/gausscheby1.hpp
+++ b/include/integratorxx/quadratures/gausscheby1.hpp
@@ -32,11 +32,9 @@ namespace IntegratorXX {
 template <typename PointType, typename WeightType>
 class GaussChebyshev1
     : public Quadrature<GaussChebyshev1<PointType, WeightType>> {
+  using base_type = Quadrature<GaussChebyshev1<PointType, WeightType>>;
 
-  using base_type =
-      Quadrature<GaussChebyshev1<PointType, WeightType>>;
-
-public:
+ public:
   using point_type = typename base_type::point_type;
   using weight_type = typename base_type::weight_type;
   using point_container = typename base_type::point_container;
@@ -51,38 +49,41 @@ public:
 
 template <typename PointType, typename WeightType>
 struct quadrature_traits<GaussChebyshev1<PointType, WeightType>> {
-
   using point_type = PointType;
   using weight_type = WeightType;
 
   using point_container = std::vector<point_type>;
   using weight_container = std::vector<weight_type>;
 
-  inline static std::tuple<point_container, weight_container>
-  generate(size_t npts, point_type lo, point_type up) {
-
+  inline static std::tuple<point_container, weight_container> generate(
+      size_t npts, point_type lo, point_type up) {
     point_container points(npts);
     weight_container weights(npts);
 
     const weight_type pi_ov_npts = M_PI / npts;
     const weight_type pi_ov_2npts = pi_ov_npts / 2;
 
-    for (size_t i = 0; i < npts; ++i) {
-      const auto ti = (2.0 * (i + 1) - 1.) * pi_ov_2npts;
+    for(size_t idx = 0; idx < npts; ++idx) {
+      // Transform index here for two reasons: the mathematical
+      // equations are for 1 <= i <= n, and the nodes are generated in
+      // decreasing order. This generates them in the right order
+      size_t i = npts - idx;
+
       // The standard nodes and weights are given by
-      const auto xi = std::cos(ti); 
+      const auto ti = (2.0 * i - 1.0) * pi_ov_2npts;
+      const auto xi = std::cos(ti);
       auto wi = pi_ov_npts;
 
       // However, as we're integrating f(x) not \frac{f(x)}{\sqrt{1 -
       // x^2}}, we must factor the \sqrt{1-x^2} into the weight
-      wi *= std::sqrt(1. - xi*xi);
+      wi *= std::sqrt(1.0 - xi * xi);
 
       // Store into memory
-      points[i]  = xi;
-      weights[i] = wi;
+      points[idx] = xi;
+      weights[idx] = wi;
     }
 
     return std::make_tuple(points, weights);
   }
 };
-} // namespace IntegratorXX
+}  // namespace IntegratorXX

--- a/include/integratorxx/quadratures/gausscheby2_mod.hpp
+++ b/include/integratorxx/quadratures/gausscheby2_mod.hpp
@@ -35,10 +35,9 @@ namespace IntegratorXX {
 template <typename PointType, typename WeightType>
 class GaussChebyshev2Modified
     : public Quadrature<GaussChebyshev2Modified<PointType, WeightType>> {
-
   using base_type = Quadrature<GaussChebyshev2Modified<PointType, WeightType>>;
 
-public:
+ public:
   using point_type = typename base_type::point_type;
   using weight_type = typename base_type::weight_type;
   using point_container = typename base_type::point_container;
@@ -53,33 +52,38 @@ public:
 
 template <typename PointType, typename WeightType>
 struct quadrature_traits<GaussChebyshev2Modified<PointType, WeightType>> {
-
   using point_type = PointType;
   using weight_type = WeightType;
 
   using point_container = std::vector<point_type>;
   using weight_container = std::vector<weight_type>;
 
-  inline static std::tuple<point_container, weight_container>
-  generate(size_t npts, point_type lo, point_type up) {
-
+  inline static std::tuple<point_container, weight_container> generate(
+      size_t npts, point_type lo, point_type up) {
     const weight_type oonpp = 1.0 / (npts + 1);
 
     point_container points(npts);
     weight_container weights(npts);
-    for (size_t i = 1; i <= npts; ++i) {
+    for(size_t idx = 0; idx < npts; ++idx) {
+      // Transform index here for two reasons: the mathematical
+      // equations are for 1 <= i <= n, and the nodes are generated in
+      // decreasing order. This generates them in the right order
+      size_t i = npts - idx;
+
       const auto ti = i * M_PI * oonpp;
       const auto sine = std::sin(ti);
       const auto sinesq = sine * sine;
       const auto cosine = std::cos(ti);
 
-      points[i - 1] = 1.0 - 2.0 * i * oonpp +
-                      M_2_PI * (1.0 + 2.0 / 3.0 * sinesq) * cosine * sine;
-      weights[i - 1] = 16.0 / 3.0 / (npts + 1.0) * sinesq * sinesq;
+      // Eq 32 in Perez-Jorda et al, 1994, doi:10.1063/1.467061
+      points[idx] = 1.0 - 2.0 * i * oonpp +
+                    M_2_PI * (1.0 + 2.0 / 3.0 * sinesq) * cosine * sine;
+      // Eq 33 in Perez-Jorda et al, 1994, doi:10.1063/1.467061
+      weights[idx] = 16.0 / 3.0 / (npts + 1.0) * sinesq * sinesq;
     }
 
     return std::make_tuple(points, weights);
   }
 };
 
-} // namespace IntegratorXX
+}  // namespace IntegratorXX

--- a/include/integratorxx/quadratures/gausscheby3.hpp
+++ b/include/integratorxx/quadratures/gausscheby3.hpp
@@ -13,7 +13,8 @@ namespace IntegratorXX {
  *
  *  The original nodes and weights from the rule are given by
  *
- *  \f{eqnarray*}{ x_{i} = & \cos^2 \displaystyle \frac {(2i-1) \pi} {2(2n+1)}  \\ w_{i} = & \displaystyle \frac {2 \pi} {2n+1} x_i \f}
+ *  \f{eqnarray*}{ x_{i} = & \cos^2 \displaystyle \frac {(2i-1) \pi} {2(2n+1)}
+ * \\ w_{i} = & \displaystyle \frac {2 \pi} {2n+1} x_i \f}
  *
  *  Reference:
  *  Abramowitz and Stegun, Handbook of Mathematical Functions with
@@ -30,10 +31,9 @@ namespace IntegratorXX {
 template <typename PointType, typename WeightType>
 class GaussChebyshev3
     : public Quadrature<GaussChebyshev3<PointType, WeightType>> {
-
   using base_type = Quadrature<GaussChebyshev3<PointType, WeightType>>;
 
-public:
+ public:
   using point_type = typename base_type::point_type;
   using weight_type = typename base_type::weight_type;
   using point_container = typename base_type::point_container;
@@ -48,39 +48,41 @@ public:
 
 template <typename PointType, typename WeightType>
 struct quadrature_traits<GaussChebyshev3<PointType, WeightType>> {
-
   using point_type = PointType;
   using weight_type = WeightType;
 
   using point_container = std::vector<point_type>;
   using weight_container = std::vector<weight_type>;
 
-  inline static std::tuple<point_container, weight_container>
-  generate(size_t npts, point_type lo, point_type up) {
-
-    const weight_type pi_ov_2n_p_1 = M_PI / (2*npts + 1);
+  inline static std::tuple<point_container, weight_container> generate(
+      size_t npts, point_type lo, point_type up) {
+    const weight_type pi_ov_2n_p_1 = M_PI / (2 * npts + 1);
 
     weight_container weights(npts);
     point_container points(npts);
-    for (size_t i = 0; i < npts; ++i) {
-      const auto ti = 0.5 * (2*(i+1) - 1) * pi_ov_2n_p_1;
-      const auto cti = std::cos(ti);
+    for(size_t idx = 0; idx < npts; ++idx) {
+      // Transform index here for two reasons: the mathematical
+      // equations are for 1 <= i <= n, and the nodes are generated in
+      // decreasing order. This generates them in the right order
+      size_t i = npts - idx;
+
       // The standard nodes and weights are given by
-      const auto xi = cti * cti; // cos^2(t)
-      auto wi = 2.0*pi_ov_2n_p_1 * xi;
+      const auto ti = 0.5 * (2 * i - 1) * pi_ov_2n_p_1;
+      const auto cti = std::cos(ti);
+      const auto xi = cti * cti;  // cos^2(t)
+      auto wi = 2.0 * pi_ov_2n_p_1 * xi;
 
       // However, since we want the rule with a unit weight factor, we
       // divide the weights by sqrt(x/(1-x)).
-      wi *= std::sqrt((1.0 - xi)/xi);
+      wi *= std::sqrt((1.0 - xi) / xi);
 
       // Finally, convert from [0,1] to [-1,1]
-      points[i] = 2*xi - 1.0;
-      weights[i] = 2.0 * wi;
+      points[idx] = 2 * xi - 1.0;
+      weights[idx] = 2.0 * wi;
     }
 
     return std::make_tuple(points, weights);
   }
 };
 
-
-} // namespace IntegratorXX
+}  // namespace IntegratorXX

--- a/test/1d_quadratures.cxx
+++ b/test/1d_quadratures.cxx
@@ -28,7 +28,7 @@ assoc_legendre( const IntT l, const IntT m, const T x ) {
     T fact = 1.;
     for( IntT i = 0; i < m; ++i ) {
       pmm *= fact*somx2;
-      fact += 2.; 
+      fact += 2.;
     }
 
   }
@@ -99,7 +99,7 @@ constexpr std::complex<T> spherical_harmonics( int64_t l, int64_t m, T theta, T 
     prefactor *= std::pow(-1,std::abs(m)) * T(factorial(l-m))/T(factorial(l+m));
 
 
-  return prefactor * assoc_legendre( l, std::abs(m), std::cos(theta) ) * 
+  return prefactor * assoc_legendre( l, std::abs(m), std::cos(theta) ) *
          std::complex<T>( std::cos(m*phi), std::sin(m*phi) );
 
 }
@@ -119,9 +119,9 @@ constexpr T real_spherical_harmonics( int64_t l, int64_t m, Args&&... args ) {
 
   const T phase = std::sqrt(2.) * ((m % 2) ? 1. : -1.);
 
-  if( m == 0 ) 
+  if( m == 0 )
     return std::real(spherical_harmonics( l, m, std::forward<Args>(args)... ));
-  else if( m < 0 ) 
+  else if( m < 0 )
     return phase * std::imag(spherical_harmonics( l, std::abs(m), std::forward<Args>(args)... ));
   else
     return phase * std::real(spherical_harmonics( l, m, std::forward<Args>(args)... ));
@@ -159,6 +159,15 @@ TEST_CASE( "Gauss-Chebyshev Quadratures", "[1d-quad]") {
   auto integrate = [&](auto& quad) {
     const auto& pts = quad.points();
     const auto& wgt = quad.weights();
+
+    // Check that nodes are in increasing value
+    for(auto i = 1; i < quad.npts(); ++i) {
+      if(pts[i] <= pts[i - 1]) {
+        std::ostringstream oss;
+        oss << "Quadrature points are not in increasing order: " << pts[i-1] << " " << pts[i] << "!\n";
+	throw std::runtime_error(oss.str());
+      }
+    }
 
     auto f = [=]( double x ){ return gaussian(x); };
 
@@ -244,25 +253,24 @@ TEST_CASE( "Lebedev-Laikov", "[1d-quad]" ) {
 
 
   auto test_fn = [&]( size_t nPts ) {
-  
+
     IntegratorXX::LebedevLaikov<double> quad( nPts );
-  
+
     const auto& pts = quad.points();
     const auto& wgt = quad.weights();
-  
-    for( auto l = 1; l < 10; ++l ) 
+
+    for( auto l = 1; l < 10; ++l )
     for( auto m = 0; m <= l; ++m ) {
-  
-      auto f = [=]( decltype(pts[0]) x ){ 
-        return spherical_harmonics(l,m,x[0],x[1],x[2]); 
+
+      auto f = [=]( decltype(pts[0]) x ){
+        return spherical_harmonics(l,m,x[0],x[1],x[2]);
       };
-  
+
       std::complex<double> res = 0.;
       for( auto i = 0; i < quad.npts(); ++i )
         res += wgt[i] * f(pts[i])* std::conj(f(pts[i]));
   
       CHECK( std::real(res) == Catch::Approx(1.) );
-  
     }
 
   };


### PR DESCRIPTION
Per @loriab comment in #27,  `gausscheby1` had a wrong equation in the code. This is fixed by this PR.

This PR also converts all `gausscheby` routines to use the same indexing. In my opinion, it is best to choose the indexing such that the equations match the mathematical expressions, since this makes checking their correctness easier.

The third thing this PR does is to make sure that all Gauss-Chebyshev quadratures generate nodes in ascending order.

(The correctness bugs were already fixed in #32.)