### PR TITLE
Clean up the Gauss-Legendre quadrature code

### DIFF
--- a/test/1d_quadratures.cxx
+++ b/test/1d_quadratures.cxx
@@ -130,42 +130,26 @@ constexpr T real_spherical_harmonics( int64_t l, int64_t m, Args&&... args ) {
 
 TEST_CASE( "Gauss-Legendre Quadratures", "[1d-quad]" ) {
 
-  constexpr unsigned order = 10;
+  for(unsigned order=10;order<14;order++) {
+    std::ostringstream oss;
+    oss << "order " << order;
+    SECTION( oss.str()) {
 
-  SECTION( "untransformed bounds" ) {
-    IntegratorXX::GaussLegendre<double,double> quad( order, -1, 1 );
+      IntegratorXX::GaussLegendre<double,double> quad( order );
 
-    const auto& pts = quad.points();
-    const auto& wgt = quad.weights();
+      const auto& pts = quad.points();
+      const auto& wgt = quad.weights();
 
-    auto f = [=]( double x ){ return gaussian(x); };
+      auto f = [=]( double x ){ return gaussian(x); };
 
-    double res = 0.;
-    for( auto i = 0; i < quad.npts(); ++i ) {
-      res += wgt[i] * f(pts[i]);
+      double res = 0.;
+      for( auto i = 0; i < quad.npts(); ++i ) {
+        res += wgt[i] * f(pts[i]);
+      }
+
+      CHECK( res == Catch::Approx(ref_gaussian_int(-1.,1.)) );
     }
-
-    CHECK( res == Catch::Approx(ref_gaussian_int(-1.,1.)) );
   }
-
-
-  SECTION( "transformed bounds" ) {
-    const double lo = 0.;
-    const double up = 4.;
-    IntegratorXX::GaussLegendre<double,double> quad( 100, lo, up );
-
-    const auto& pts = quad.points();
-    const auto& wgt = quad.weights();
-
-    auto f = [=]( double x ){ return gaussian(x); };
-
-    double res = 0.;
-    for( auto i = 0; i < quad.npts(); ++i )
-      res += wgt[i] * f(pts[i]);
-
-    CHECK( res == Catch::Approx(ref_gaussian_int(lo,up)) );
-  }
-  
 }
 
 TEST_CASE( "Gauss-Chebyshev Quadratures", "[1d-quad]") {

--- a/test/quadrature_manipulation.cxx
+++ b/test/quadrature_manipulation.cxx
@@ -7,11 +7,11 @@ TEST_CASE( "Constructor", "[quad]" ) {
   using base_type = IntegratorXX::Quadrature<quad_type>;
 
   SECTION("Basic") {
-    quad_type q( 10, -1, 1 );  
+    quad_type q( 10 );
   }
 
   SECTION("Copy To Base") {
-    quad_type q( 10, -1, 1 );  
+    quad_type q( 10 );
     base_type b(q);
 
     CHECK( q.points() == b.points() );
@@ -19,7 +19,7 @@ TEST_CASE( "Constructor", "[quad]" ) {
   }
 
   SECTION("Move to Base") {
-    quad_type q( 10, -1, 1 );  
+    quad_type q( 10 );
     std::vector<double> pts = q.points();
     std::vector<double> wgt = q.weights();
 


### PR DESCRIPTION
Cleanups to Gauss-Legendre quadrature. Now the code also works for odd numbers of points. I also checked that the nodes are returned in increasing order.

In my opinion, transformations should not be hardcoded in the individual quadrature rule; instead, the transformation should be applied later.