### PR TITLE
Gauss-Legendre Fixes

### DIFF
--- a/include/integratorxx/quadratures/gausslegendre.hpp
+++ b/include/integratorxx/quadratures/gausslegendre.hpp
@@ -115,7 +115,7 @@ struct quadrature_traits<
 
         if(not converged) {
           throw std::runtime_error(
-            "Gauss-Legendre Netwon Iterations Failed to Converge"
+            "Gauss-Legendre Newton Iterations Failed to Converge"
           );
         }
 

--- a/include/integratorxx/quadratures/gausslegendre.hpp
+++ b/include/integratorxx/quadratures/gausslegendre.hpp
@@ -104,7 +104,7 @@ struct quadrature_traits<
 
           // Newton update for root
           z_old = z;
-          z  = z_old - p_n / dp_n;
+          z  -= p_n / dp_n;
 
           // Convergence check
           if(std::abs(z-z_old) <= eps) {


### PR DESCRIPTION
1. Tightens convergence tolerance (1e-11 -> epsilon) for Gauss-Legendre Newton iterations 
2. Makes GL iterations of fixed range to avoid infinite loops
3. Moves to structured bindings for `eval_Pn` return

Closes #40.