### PR TITLE
Exploit Node Symmetry in Gauss-Chebyshev Quadratures

### DIFF
--- a/include/integratorxx/quadratures/gausschebyshev1.hpp
+++ b/include/integratorxx/quadratures/gausschebyshev1.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <integratorxx/quadrature.hpp>
-#include <iostream>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/gausschebyshev1.hpp
+++ b/include/integratorxx/quadratures/gausschebyshev1.hpp
@@ -63,7 +63,8 @@ struct quadrature_traits<GaussChebyshev1<PointType, WeightType>> {
     const weight_type pi_ov_npts = M_PI / npts;
     const weight_type pi_ov_2npts = pi_ov_npts / 2;
 
-    for(size_t idx = 0; idx < npts; ++idx) {
+    // Generate the first half explicitly and reflect
+    for(size_t idx = 0; idx < npts/2; ++idx) {
       // Transform index here for two reasons: the mathematical
       // equations are for 1 <= i <= n, and the nodes are generated in
       // decreasing order. This generates them in the right order
@@ -79,9 +80,20 @@ struct quadrature_traits<GaussChebyshev1<PointType, WeightType>> {
       wi *= std::sqrt(1.0 - xi * xi);
 
       // Store into memory
-      points[idx] = xi;
+      points[idx]  = xi;
       weights[idx] = wi;
+
+      // Reflect to second half
+      points[i-1]  = -xi;
+      weights[i-1] = wi; 
     }
+
+    // Edge case for odd points
+    if(npts % 2) {
+      points[npts/2]  = 0.0;
+      weights[npts/2] = pi_ov_npts;
+    }
+
 
     return std::make_tuple(points, weights);
   }

--- a/include/integratorxx/quadratures/gausschebyshev2.hpp
+++ b/include/integratorxx/quadratures/gausschebyshev2.hpp
@@ -63,7 +63,9 @@ struct quadrature_traits<GaussChebyshev2<PointType, WeightType>> {
 
     weight_container weights(npts);
     point_container points(npts);
-    for(size_t idx = 0; idx < npts; ++idx) {
+
+    // Generate the first half explicitly and reflect
+    for(size_t idx = 0; idx < npts/2; ++idx) {
       // Transform index here for two reasons: the mathematical
       // equations are for 1 <= i <= n, and the nodes are generated in
       // decreasing order. This generates them in the right order
@@ -80,6 +82,16 @@ struct quadrature_traits<GaussChebyshev2<PointType, WeightType>> {
       // Store into memory
       points[idx] = xi;
       weights[idx] = wi;
+
+      // Reflect to second half
+      points[i-1]  = -xi;
+      weights[i-1] = wi; 
+    }
+
+    // Edge case for odd points
+    if(npts % 2) {
+      points[npts/2]  = 0.0;
+      weights[npts/2] = pi_ov_npts_p_1;
     }
 
     return std::make_tuple(points, weights);

--- a/include/integratorxx/quadratures/gausschebyshev2modified.hpp
+++ b/include/integratorxx/quadratures/gausschebyshev2modified.hpp
@@ -64,7 +64,10 @@ struct quadrature_traits<GaussChebyshev2Modified<PointType, WeightType>> {
 
     point_container points(npts);
     weight_container weights(npts);
-    for(size_t idx = 0; idx < npts; ++idx) {
+
+
+    // Generate the first half explicitly and reflect
+    for(size_t idx = 0; idx < npts/2; ++idx) {
       // Transform index here for two reasons: the mathematical
       // equations are for 1 <= i <= n, and the nodes are generated in
       // decreasing order. This generates them in the right order
@@ -80,6 +83,16 @@ struct quadrature_traits<GaussChebyshev2Modified<PointType, WeightType>> {
                     M_2_PI * (1.0 + 2.0 / 3.0 * sinesq) * cosine * sine;
       // Eq 33 in Perez-Jorda et al, 1994, doi:10.1063/1.467061
       weights[idx] = 16.0 / 3.0 / (npts + 1.0) * sinesq * sinesq;
+
+      // Reflect to second half
+      points[i-1]  = -points[idx];
+      weights[i-1] = weights[idx]; 
+    }
+
+    // Edge case for odd points
+    if(npts % 2) {
+      points[npts/2]  = 0.0;
+      weights[npts/2] = 16.0 / 3.0 / (npts + 1.0);
     }
 
     return std::make_tuple(points, weights);

--- a/test/1d_quadratures.cxx
+++ b/test/1d_quadratures.cxx
@@ -180,19 +180,12 @@ TEST_CASE( "Gauss-Lobatto Quadratures", "[1d-quad]" ) {
 
 TEST_CASE( "Gauss-Chebyshev Quadratures", "[1d-quad]") {
 
-  constexpr unsigned order = 200;
   auto integrate = [&](auto& quad) {
     const auto& pts = quad.points();
     const auto& wgt = quad.weights();
 
     // Check that nodes are in increasing value
-    for(auto i = 1; i < quad.npts(); ++i) {
-      if(pts[i] <= pts[i - 1]) {
-        std::ostringstream oss;
-        oss << "Quadrature points are not in increasing order: " << pts[i-1] << " " << pts[i] << "!\n";
-	throw std::runtime_error(oss.str());
-      }
-    }
+    CHECK(std::is_sorted(pts.begin(), pts.end()));
 
     auto f = [=]( double x ){ return gaussian(x); };
 
@@ -205,19 +198,25 @@ TEST_CASE( "Gauss-Chebyshev Quadratures", "[1d-quad]") {
   };
 
   SECTION("First Kind") {
-    IntegratorXX::GaussChebyshev1<double, double> quad(order, -1., 1.);
-    integrate(quad);
+    IntegratorXX::GaussChebyshev1<double, double> quad_even(200, -1., 1.);
+    integrate(quad_even);
+    IntegratorXX::GaussChebyshev1<double, double> quad_odd(201, -1., 1.);
+    integrate(quad_odd);
   }
   SECTION("Second Kind") {
-    IntegratorXX::GaussChebyshev2<double, double> quad(order, -1., 1.);
-    integrate(quad);
+    IntegratorXX::GaussChebyshev2<double, double> quad_even(200, -1., 1.);
+    integrate(quad_even);
+    IntegratorXX::GaussChebyshev2<double, double> quad_odd(201, -1., 1.);
+    integrate(quad_odd);
   }
   SECTION("Second Kind (Modified)") {
-    IntegratorXX::GaussChebyshev2Modified<double, double> quad(order, -1., 1.);
-    integrate(quad);
+    IntegratorXX::GaussChebyshev2Modified<double, double> quad_even(200, -1., 1.);
+    integrate(quad_even);
+    IntegratorXX::GaussChebyshev2Modified<double, double> quad_odd(201, -1., 1.);
+    integrate(quad_odd);
   }
   SECTION("Third Kind") {
-    IntegratorXX::GaussChebyshev3<double, double> quad(order, -1., 1.);
+    IntegratorXX::GaussChebyshev3<double, double> quad(200, -1., 1.);
     integrate(quad);
   }
 }


### PR DESCRIPTION
Closes #39.

Quadratures:
- [x] `GaussChebyshev1`
- [x] `GaussChebyshev2`
- [x] `GaussChebyshev2Modified` 