### PR TITLE
Need to include <vector> for primitive quadratures

### DIFF
--- a/include/integratorxx/quadratures/primitive/gausschebyshev1.hpp
+++ b/include/integratorxx/quadratures/primitive/gausschebyshev1.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <integratorxx/quadrature.hpp>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/primitive/gausschebyshev2.hpp
+++ b/include/integratorxx/quadratures/primitive/gausschebyshev2.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <integratorxx/quadrature.hpp>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/primitive/gausschebyshev2modified.hpp
+++ b/include/integratorxx/quadratures/primitive/gausschebyshev2modified.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <integratorxx/quadrature.hpp>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/primitive/gausschebyshev3.hpp
+++ b/include/integratorxx/quadratures/primitive/gausschebyshev3.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <integratorxx/quadrature.hpp>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/primitive/gausslegendre.hpp
+++ b/include/integratorxx/quadratures/primitive/gausslegendre.hpp
@@ -2,6 +2,7 @@
 
 #include <integratorxx/quadrature.hpp>
 #include <integratorxx/util/legendre.hpp>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/primitive/gausslobatto.hpp
+++ b/include/integratorxx/quadratures/primitive/gausslobatto.hpp
@@ -2,6 +2,7 @@
 
 #include <integratorxx/quadrature.hpp>
 #include <integratorxx/util/legendre.hpp>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/primitive/uniform.hpp
+++ b/include/integratorxx/quadratures/primitive/uniform.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <integratorxx/quadrature.hpp>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/radial/muraknowles.hpp
+++ b/include/integratorxx/quadratures/radial/muraknowles.hpp
@@ -2,6 +2,7 @@
 
 #include <integratorxx/quadratures/primitive/uniform.hpp>
 #include <integratorxx/quadratures/radial/radial_transform.hpp>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/s2/ahrens_beylkin.hpp
+++ b/include/integratorxx/quadratures/s2/ahrens_beylkin.hpp
@@ -3,6 +3,7 @@
 #include <integratorxx/quadrature.hpp>
 #include <integratorxx/quadratures/s2/ahrens_beylkin/ahrens_beylkin_grids.hpp>
 #include <integratorxx/util/copy_grid.hpp>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/s2/delley.hpp
+++ b/include/integratorxx/quadratures/s2/delley.hpp
@@ -3,6 +3,7 @@
 #include <integratorxx/quadrature.hpp>
 #include <integratorxx/util/copy_grid.hpp>
 #include <integratorxx/quadratures/s2/delley/delley_grids.hpp>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/s2/lebedev_laikov.hpp
+++ b/include/integratorxx/quadratures/s2/lebedev_laikov.hpp
@@ -3,6 +3,7 @@
 #include <integratorxx/quadrature.hpp>
 #include <integratorxx/quadratures/s2/lebedev_laikov/lebedev_laikov_grids.hpp>
 #include <integratorxx/util/copy_grid.hpp>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/s2/womersley.hpp
+++ b/include/integratorxx/quadratures/s2/womersley.hpp
@@ -4,6 +4,7 @@
 #include <integratorxx/util/copy_grid.hpp>
 #include <integratorxx/util/create_array.hpp>
 #include <integratorxx/quadratures/s2/womersley/womersley_grids.hpp>
+#include <vector>
 
 namespace IntegratorXX {
 


### PR DESCRIPTION
The primitive quadratures use `std::vector` which means one needs to include it.