### PR TITLE
Make every header self-contained

### DIFF
--- a/include/integratorxx/batch/spherical_micro_batcher.hpp
+++ b/include/integratorxx/batch/spherical_micro_batcher.hpp
@@ -7,6 +7,14 @@
 #include <iomanip>
 #include <vector>
 #include <array>
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+#include <tuple>
+#include <utility>
 
 
 namespace IntegratorXX {

--- a/include/integratorxx/composite_quadratures/product_quadrature.hpp
+++ b/include/integratorxx/composite_quadratures/product_quadrature.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <integratorxx/quadrature.hpp>
+#include <memory>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/composite_quadratures/pruned_spherical_quadrature.hpp
+++ b/include/integratorxx/composite_quadratures/pruned_spherical_quadrature.hpp
@@ -6,6 +6,9 @@
 #include <integratorxx/type_traits.hpp>
 
 #include <utility>
+#include <cassert>
+#include <memory>
+#include <vector>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/composite_quadratures/spherical_quadrature.hpp
+++ b/include/integratorxx/composite_quadratures/spherical_quadrature.hpp
@@ -3,6 +3,7 @@
 #include <integratorxx/composite_quadratures/product_quadrature.hpp>
 #include <integratorxx/types.hpp>
 #include <integratorxx/type_traits.hpp>
+#include <memory>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/composite_quadratures/sub_quadrature.hpp
+++ b/include/integratorxx/composite_quadratures/sub_quadrature.hpp
@@ -2,6 +2,8 @@
 
 #include <integratorxx/quadrature.hpp>
 #include <cassert>
+#include <tuple>
+#include <utility>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadrature.hpp
+++ b/include/integratorxx/quadrature.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <cassert>
+#include <utility>
 #include <integratorxx/type_traits.hpp>
 
 namespace IntegratorXX {

--- a/include/integratorxx/quadratures/primitive/gausschebyshev1.hpp
+++ b/include/integratorxx/quadratures/primitive/gausschebyshev1.hpp
@@ -2,6 +2,7 @@
 
 #include <integratorxx/quadrature.hpp>
 #include <vector>
+#include <cmath>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/primitive/gausschebyshev2.hpp
+++ b/include/integratorxx/quadratures/primitive/gausschebyshev2.hpp
@@ -2,6 +2,7 @@
 
 #include <integratorxx/quadrature.hpp>
 #include <vector>
+#include <cmath>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/primitive/gausschebyshev2modified.hpp
+++ b/include/integratorxx/quadratures/primitive/gausschebyshev2modified.hpp
@@ -2,6 +2,7 @@
 
 #include <integratorxx/quadrature.hpp>
 #include <vector>
+#include <cmath>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/primitive/gausschebyshev3.hpp
+++ b/include/integratorxx/quadratures/primitive/gausschebyshev3.hpp
@@ -2,6 +2,7 @@
 
 #include <integratorxx/quadrature.hpp>
 #include <vector>
+#include <cmath>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/primitive/gausslegendre.hpp
+++ b/include/integratorxx/quadratures/primitive/gausslegendre.hpp
@@ -3,6 +3,10 @@
 #include <integratorxx/quadrature.hpp>
 #include <integratorxx/util/legendre.hpp>
 #include <vector>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <tuple>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/primitive/gausslobatto.hpp
+++ b/include/integratorxx/quadratures/primitive/gausslobatto.hpp
@@ -3,6 +3,10 @@
 #include <integratorxx/quadrature.hpp>
 #include <integratorxx/util/legendre.hpp>
 #include <vector>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <tuple>
 
 namespace IntegratorXX {
 
@@ -47,7 +51,7 @@ struct quadrature_traits<GaussLobatto<PointType, WeightType>> {
     for(size_t idx = 1; idx < mid; ++idx) {
       // Initial guess
       const point_type i = static_cast<point_type>(npts - 1 - idx);
-      point_type z = cos (i * M_PI / ( npts - 1.0));
+      point_type z = std::cos(i * M_PI / (npts - 1.0));
 
       // Old value of root
       point_type z_old = -2.0;

--- a/include/integratorxx/quadratures/radial/becke.hpp
+++ b/include/integratorxx/quadratures/radial/becke.hpp
@@ -2,6 +2,7 @@
 
 #include <integratorxx/quadratures/primitive/gausschebyshev2.hpp>
 #include <integratorxx/quadratures/radial/radial_transform.hpp>
+#include <cmath>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/radial/mhl.hpp
+++ b/include/integratorxx/quadratures/radial/mhl.hpp
@@ -2,6 +2,7 @@
 
 #include <integratorxx/quadratures/primitive/uniform.hpp>
 #include <integratorxx/quadratures/radial/radial_transform.hpp>
+#include <cmath>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/radial/muraknowles.hpp
+++ b/include/integratorxx/quadratures/radial/muraknowles.hpp
@@ -3,6 +3,7 @@
 #include <integratorxx/quadratures/primitive/uniform.hpp>
 #include <integratorxx/quadratures/radial/radial_transform.hpp>
 #include <vector>
+#include <cmath>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/radial/radial_transform.hpp
+++ b/include/integratorxx/quadratures/radial/radial_transform.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <memory>
+#include <cstddef>
+#include <tuple>
 
 #include <integratorxx/quadrature.hpp>
 

--- a/include/integratorxx/quadratures/radial/treutlerahlrichs.hpp
+++ b/include/integratorxx/quadratures/radial/treutlerahlrichs.hpp
@@ -2,6 +2,7 @@
 
 #include <integratorxx/quadratures/primitive/gausschebyshev2.hpp>
 #include <integratorxx/quadratures/radial/radial_transform.hpp>
+#include <cmath>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/s2/ahrens_beylkin.hpp
+++ b/include/integratorxx/quadratures/s2/ahrens_beylkin.hpp
@@ -4,6 +4,7 @@
 #include <integratorxx/quadratures/s2/ahrens_beylkin/ahrens_beylkin_grids.hpp>
 #include <integratorxx/util/copy_grid.hpp>
 #include <vector>
+#include <cmath>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/s2/delley.hpp
+++ b/include/integratorxx/quadratures/s2/delley.hpp
@@ -4,6 +4,7 @@
 #include <integratorxx/util/copy_grid.hpp>
 #include <integratorxx/quadratures/s2/delley/delley_grids.hpp>
 #include <vector>
+#include <cmath>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/s2/lebedev_laikov.hpp
+++ b/include/integratorxx/quadratures/s2/lebedev_laikov.hpp
@@ -4,6 +4,7 @@
 #include <integratorxx/quadratures/s2/lebedev_laikov/lebedev_laikov_grids.hpp>
 #include <integratorxx/util/copy_grid.hpp>
 #include <vector>
+#include <cmath>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/quadratures/s2/womersley.hpp
+++ b/include/integratorxx/quadratures/s2/womersley.hpp
@@ -5,6 +5,7 @@
 #include <integratorxx/util/create_array.hpp>
 #include <integratorxx/quadratures/s2/womersley/womersley_grids.hpp>
 #include <vector>
+#include <cmath>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/util/bound_transform.hpp
+++ b/include/integratorxx/util/bound_transform.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <cassert>
+#include <tuple>
 
 #include <limits>
 

--- a/include/integratorxx/util/copy_grid.hpp
+++ b/include/integratorxx/util/copy_grid.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/util/create_array.hpp
+++ b/include/integratorxx/util/create_array.hpp
@@ -1,4 +1,7 @@
 #pragma once
+#include <array>
+#include <cstddef>
+#include <utility>
 
 namespace IntegratorXX {
 

--- a/include/integratorxx/util/legendre.hpp
+++ b/include/integratorxx/util/legendre.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <tuple>
 
 namespace IntegratorXX {


### PR DESCRIPTION
None of the library headers could be relied upon to compile on their own;
they worked only when something else had already pulled in the standard
headers they use. Compiling each non-data header in isolation produced
eight hard failures:

* spherical_micro_batcher.hpp calls std::any_of, std::minmax_element,
  std::partition, std::sort, std::unique and std::set_union without
  <algorithm>.
* product_quadrature.hpp declares std::unique_ptr members without
  <memory>, so the class had no members at all when compiled alone. This
  cascaded into spherical_quadrature.hpp, pruned_spherical_quadrature.hpp
  and the batcher.
* util/create_array.hpp uses std::array and std::index_sequence,
  util/copy_grid.hpp uses std::copy, util/legendre.hpp uses size_t, and
  util/bound_transform.hpp uses assert and std::tuple, none of them
  declared.

Separately, <cmath> was not included anywhere in the library, although
std::cos, std::sin, std::sqrt, std::pow, std::log and std::abs are used
throughout and M_PI appears in nine places. The two Newton solvers also
use std::numeric_limits and std::runtime_error without <limits> or
<stdexcept>.

Add the includes each header actually needs. Also qualify the one
unqualified cos() call in gausslobatto.hpp: <cmath> is not required to
place names in the global namespace, so it only resolved because <math.h>
happened to be reachable.

Every non-data header now compiles standalone.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FDTFYJMQ76iujDFNHzZyXF
